### PR TITLE
feat (FE-COMP-9): Adição componente Tooltip

### DIFF
--- a/src/components/Tooltip/Tooltip.jsx
+++ b/src/components/Tooltip/Tooltip.jsx
@@ -1,0 +1,26 @@
+import styles from "./Tooltip.module.css"; 
+
+const Tooltip = ({variant, content, onClick, buttonType = "default", buttonLabel,}) => {
+  const getButtonText = () => {
+    if (buttonLabel) return buttonLabel;
+    switch (buttonType) {
+      case "fechar":
+        return "Fechar";
+      default:
+        return "Ok";
+    }
+  };
+
+  return (
+    <div className={styles.tooltip}> {/* Use styles.nomeDaClasse */}
+      {content}
+      {variant === "withButton" && (
+        <button className={styles.button} onClick={onClick}>
+          {getButtonText()}
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default Tooltip;

--- a/src/components/Tooltip/Tooltip.jsx
+++ b/src/components/Tooltip/Tooltip.jsx
@@ -6,7 +6,7 @@ const Tooltip = ({
   variant,
   content,
   onClick,
-  buttonType = "default",
+  buttonVariant = "Btn-lbl",
   buttonLabel,
   position = "top", // posição padrão do tooltip
 }) => {
@@ -48,7 +48,7 @@ const Tooltip = ({
         <div className={styles.tooltipContent}>
           {content}
           {variant === "withButton" && (
-            <Button onClick={handleButtonClick} type={buttonType}>
+            <Button onClick={handleButtonClick} variant={buttonVariant} label={buttonLabel}>
               {getButtonText()}
             </Button>
           )}

--- a/src/components/Tooltip/Tooltip.jsx
+++ b/src/components/Tooltip/Tooltip.jsx
@@ -1,24 +1,66 @@
-import styles from "./Tooltip.module.css"; 
+import React, { useState } from "react";
+import styles from "./Tooltip.module.css";
+import Button from "../Buttons/Button/Button";
 
-const Tooltip = ({variant, content, onClick, buttonType = "default", buttonLabel,}) => {
+const Tooltip = ({
+  variant,
+  content,
+  onClick,
+  buttonType = "default",
+  buttonLabel,
+  position = "top", // posição padrão do tooltip
+}) => {
+  const [isVisible, setIsVisible] = useState(false);
+
   const getButtonText = () => {
-    if (buttonLabel) return buttonLabel;
-    switch (buttonType) {
-      case "fechar":
-        return "Fechar";
-      default:
-        return "Ok";
-    }
+    return buttonLabel || "Ok"; //"Ok" como padrão
+  };
+
+  const handleMouseEnter = () => {
+    setIsVisible(true);
+  };
+
+  const handleMouseLeave = () => {
+    setIsVisible(false);
+  };
+
+  const handleButtonClick = () => {
+    setIsVisible(false);
+    if (onClick) onClick();
+  };
+
+  const handleCloseClick = () => {
+    setIsVisible(false);
   };
 
   return (
-    <div className={styles.tooltip}> {/* Use styles.nomeDaClasse */}
-      {content}
-      {variant === "withButton" && (
-        <button className={styles.button} onClick={onClick}>
-          {getButtonText()}
-        </button>
-      )}
+    <div
+      className={styles.tooltipWrapper}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      <div
+        className={`${styles.tooltip} ${
+          isVisible ? styles.visible : styles.hidden
+        } ${styles[position]}`} // adiciona dinamicamente uma classe CSS com base no valor da prop position
+      >
+        <div className={`${styles.tooltipArrow} ${styles[`arrow-${position}`]}`}></div> {/* triângulozinho da tooltip */}
+        <div className={styles.tooltipContent}>
+          {content}
+          {variant === "withButton" && (
+            <Button onClick={handleButtonClick} type={buttonType}>
+              {getButtonText()}
+            </Button>
+          )}
+          <button
+            className={styles.closeButton}
+            onClick={handleCloseClick}
+            aria-label="Close Tooltip"
+          >
+            ✕
+          </button>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/components/Tooltip/Tooltip.module.css
+++ b/src/components/Tooltip/Tooltip.module.css
@@ -1,0 +1,28 @@
+CSS
+
+.tooltip {
+  background-color: var(--black-300);
+  color: var(--base-white);
+  padding: 12px;
+  border-radius: 8px;
+  font: var(--text-light);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  margin-top: 8px;
+  max-width: 300px;
+  word-wrap: break-word;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.button {
+  margin-left: auto;
+  margin-top: auto;
+  background-color: var(--navy-500);
+  color: var(--base-white);
+  border: none;
+  padding: 6px 12px;
+  border-radius: 4px;
+  font: var(--label-small);
+  cursor: pointer;
+}

--- a/src/components/Tooltip/Tooltip.module.css
+++ b/src/components/Tooltip/Tooltip.module.css
@@ -1,28 +1,122 @@
-CSS
+.tooltipWrapper {
+  position: relative;
+  display: inline-block;
+}
 
 .tooltip {
-  background-color: var(--black-300);
-  color: var(--base-white);
+  position: absolute;
+  background-color: var(--black-300); 
+  color: var(--base-white); 
   padding: 12px;
   border-radius: 8px;
   font: var(--text-light);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  margin-top: 8px;
   max-width: 300px;
-  word-wrap: break-word;
+  white-space: pre-wrap; 
   display: flex;
   flex-direction: column;
   gap: 8px;
+  opacity: 0; 
+  transform: translateY(-10px); 
+  transition: opacity 0.3s ease, transform 0.3s ease; 
+  position: relative; 
 }
 
-.button {
-  margin-left: auto;
-  margin-top: auto;
-  background-color: var(--navy-500);
-  color: var(--base-white);
+.tooltip.visible {
+  opacity: 1; 
+  transform: translateY(0); 
+}
+
+.tooltip.hidden {
+  opacity: 0; 
+  transform: translateY(-10px); 
+}
+
+/* posições do tooltip */
+.tooltip.top {
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.tooltip.bottom {
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.tooltip.left {
+  right: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.tooltip.right {
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+/* triângulozinho da tooltip */
+.tooltipArrow {
+  position: absolute;
+  width: 0;
+  height: 0;
+  border-style: solid;
+}
+
+/* triângulozinho para cada posição */
+.arrow-top {
+  bottom: -6px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 6px 6px 0 6px;
+  border-color: var(--black-300) transparent transparent transparent;
+}
+
+.arrow-bottom {
+  top: -6px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 0 6px 6px 6px;
+  border-color: transparent transparent var(--black-300) transparent;
+}
+
+.arrow-left {
+  right: -6px;
+  top: 50%;
+  transform: translateY(-50%);
+  border-width: 6px 0 6px 6px;
+  border-color: transparent transparent transparent var(--black-300);
+}
+
+.arrow-right {
+  left: -6px;
+  top: 50%;
+  transform: translateY(-50%);
+  border-width: 6px 6px 6px 0;
+  border-color: transparent var(--black-300) transparent transparent;
+}
+
+.tooltipContent {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-right: 24px; 
+}
+
+.closeButton {
+  background: none;
   border: none;
-  padding: 6px 12px;
-  border-radius: 4px;
-  font: var(--label-small);
+  color: var(--base-white);
+  font-size: 16px;
   cursor: pointer;
+  position: absolute; 
+  top: 8px; 
+  right: 8px; 
+  z-index: 1; 
+}
+
+.closeButton:hover {
+  color: var(--navy-500); 
 }

--- a/src/components/Tooltip/Tooltip.module.css
+++ b/src/components/Tooltip/Tooltip.module.css
@@ -7,17 +7,17 @@
   position: absolute;
   background-color: var(--black-300); 
   color: var(--base-white); 
-  padding: 12px;
-  border-radius: 8px;
+  padding: 0.75rem;
+  border-radius: 0.5rem;
   font: var(--text-light);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  max-width: 300px;
+  box-shadow: 0 0.125rem 0.5rem rgba(0, 0, 0, 0.1);
+  max-width: 18.75rem;
   white-space: pre-wrap; 
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 0.5rem;
   opacity: 0; 
-  transform: translateY(-10px); 
+  transform: translateY(-0.625rem); 
   transition: opacity 0.3s ease, transform 0.3s ease; 
   position: relative; 
 }
@@ -29,10 +29,9 @@
 
 .tooltip.hidden {
   opacity: 0; 
-  transform: translateY(-10px); 
+  transform: translateY(-0.625rem); 
 }
 
-/* posições do tooltip */
 .tooltip.top {
   bottom: 100%;
   left: 50%;
@@ -57,7 +56,6 @@
   transform: translateY(-50%);
 }
 
-/* triângulozinho da tooltip */
 .tooltipArrow {
   position: absolute;
   width: 0;
@@ -65,55 +63,54 @@
   border-style: solid;
 }
 
-/* triângulozinho para cada posição */
 .arrow-top {
-  bottom: -6px;
+  bottom: -0.375rem;
   left: 50%;
   transform: translateX(-50%);
-  border-width: 6px 6px 0 6px;
+  border-width: 0.375rem 0.375rem 0 0.375rem;
   border-color: var(--black-300) transparent transparent transparent;
 }
 
 .arrow-bottom {
-  top: -6px;
+  top: -0.375rem;
   left: 50%;
   transform: translateX(-50%);
-  border-width: 0 6px 6px 6px;
+  border-width: 0 0.375rem 0.375rem 0.375rem;
   border-color: transparent transparent var(--black-300) transparent;
 }
 
 .arrow-left {
-  right: -6px;
+  right: -0.375rem;
   top: 50%;
   transform: translateY(-50%);
-  border-width: 6px 0 6px 6px;
+  border-width: 0.375rem 0 0.375rem 0.375rem;
   border-color: transparent transparent transparent var(--black-300);
 }
 
 .arrow-right {
-  left: -6px;
+  left: -0.375rem;
   top: 50%;
   transform: translateY(-50%);
-  border-width: 6px 6px 6px 0;
+  border-width: 0.375rem 0.375rem 0.375rem 0;
   border-color: transparent var(--black-300) transparent transparent;
 }
 
 .tooltipContent {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding-right: 24px; 
+  gap: 0.5rem;
+  padding-right: 1.5rem; 
 }
 
 .closeButton {
   background: none;
   border: none;
   color: var(--base-white);
-  font-size: 16px;
+  font-size: 1rem;
   cursor: pointer;
   position: absolute; 
-  top: 8px; 
-  right: 8px; 
+  top: 0.5rem; 
+  right: 0.5rem; 
   z-index: 1; 
 }
 


### PR DESCRIPTION
## ([Adição componente Tooltip](feat)/FE-COMP-9) ## 

**Branch**

- feature/tooltip-component

---

**O que foi implementado ou alterado?**

- Criação do componente Tooltip com suporte a variações: Tooltip simples com texto e Tooltip com botão acionável (via prop onClick)

- Estilização com Tooltip.module.css seguindo as variáveis globais de cor e tipografia do projeto

---

**Passos para testar**

1. Importar o componente Tooltip em qualquer parte da aplicação
2. Usar com a prop variant="default" ou variant="withButton" para testar as variações
3. No caso de withButton, passar a função onClick como prop e verificar se está sendo chamada

---

**Reviewers**
- @usuario1
- @usuario2
