### PR TITLE
Filtro de estado na página de comparação

### DIFF
--- a/src/components/Maps/BrazilMap.jsx
+++ b/src/components/Maps/BrazilMap.jsx
@@ -4,7 +4,6 @@ import statesData from "../../assets/geojson/brazil-states.json";
 import { useState, useEffect } from "react";
 import L from "leaflet";
 import "./../../App.css";
-import styles from "./Maps.module.css";
 
 const regionMap = {
   1: "Norte",
@@ -157,33 +156,8 @@ const BrazilMap = ({ onRegionChange }) => {
     ? regions[selectedRegion]
     : statesData.features;
 
-  const getDescriptionText = () => {
-    if (selectedState) {
-      return "Para desfazer a seleção de estado atual, clique no mapa abaixo.";
-    } else if (selectedRegion) {
-      return "Escolha um dos estados para analisar seus dados.";
-    } else {
-      return "Para selecionar um estado, escolha uma das regiões do mapa abaixo.";
-    }
-  };
-
-  useEffect(() => {
-    if (selectedState && selectedRegion){
-      let regionFilter = {
-        region: selectedRegion,
-        state: selectedState,
-      }
-    }
-  }, [selectedState]  )
-
   return (
     <div className="brazil-map-container">
-      <p className={styles.mapDescription}>{getDescriptionText()}</p>
-      {selectedState ? (
-        <h2 className={styles.mapCurrentState}>{selectedState}</h2>
-      ) : selectedRegion ? (
-        <h2 className={styles.mapCurrentState}>Região {selectedRegion}</h2>
-      ) : null}
 
       <MapContainer
         center={[-14.235, -51.9253]}

--- a/src/components/Maps/BrazilMap.jsx
+++ b/src/components/Maps/BrazilMap.jsx
@@ -40,6 +40,7 @@ const BrazilMap = ({ onRegionChange }) => {
   const [regions, setRegions] = useState({});
   const [selectedRegion, setSelectedRegion] = useState(null);
   const [selectedState, setSelectedState] = useState(null);
+  const [selectedUF , setSelectedUF] = useState(null)
 
   useEffect(() => {
     const grouped = {};
@@ -55,7 +56,7 @@ const BrazilMap = ({ onRegionChange }) => {
   const getSelectedStateFeature = () => {
     return Object.values(regions)
       .flat()
-      .find((f) => f.properties.name === selectedState);
+      .find((f) => f.properties.name === selectedState && f.properties.sigla === selectedUF);
   };
 
   const renderGeoJSON = () => {
@@ -80,7 +81,8 @@ const BrazilMap = ({ onRegionChange }) => {
               click: () => {
                 setSelectedRegion(null);
                 setSelectedState(null);
-                onRegionChange?.({ regiao: null, estado: null }); // reset
+                setSelectedUF(null)
+                onRegionChange?.({ regiao: null, estado: null , uf: null }); // reset
               },
             });
             layer.bindPopup(feature.properties.name);
@@ -109,10 +111,12 @@ const BrazilMap = ({ onRegionChange }) => {
           }}
           onEachFeature={(feature, layer) => {
             const stateName = feature.properties.name;
+            const stateSigla = feature.properties.sigla;
             layer.on({
               click: () => {
                 setSelectedState(stateName);
-                onRegionChange?.({ regiao: selectedRegion, estado: stateName });
+                setSelectedUF(stateSigla);
+                onRegionChange?.({ regiao: selectedRegion, estado: stateName , uf: stateSigla});
               },
             });
             layer.bindPopup(stateName);
@@ -140,7 +144,8 @@ const BrazilMap = ({ onRegionChange }) => {
             e.originalEvent.stopPropagation();
             setSelectedRegion(regionName);
             setSelectedState(null);
-            onRegionChange?.({ regiao: regionName, estado: null }); // região selecionada
+            setSelectedUF(null);
+            onRegionChange?.({ regiao: regionName, estado: null , uf: null }); // região selecionada
           },
         }}
         onEachFeature={(feature, layer) => {

--- a/src/components/Maps/Maps.module.css
+++ b/src/components/Maps/Maps.module.css
@@ -1,17 +1,4 @@
 
-/* BrazilMap */
-.mapCurrentState{
-    margin-top: 0.875rem;
-    color: var(--black-500);
-    font: var(--title-regular);
-    text-align: center;
-  }
-  
-  .mapDescription {
-    color: var(--black-500);
-    font: var(--text-medium);
-    text-align: center;
-  }
   
 /* WorldMap */
 rect{

--- a/src/components/Maps/MultiBrazilMap.jsx
+++ b/src/components/Maps/MultiBrazilMap.jsx
@@ -60,15 +60,16 @@ const BrazilMap = ({ onRegionChange }) => {
   const handleRegionClick = (regionName) => {
     setSelectedRegion(regionName);
     setZoomToBrazil(false);
-    onRegionChange?.({ regiao: regionName, estado: null });
+    onRegionChange?.({ regiao: regionName, estado: null , uf: null});
   };
 
   const handleStateClick = (stateFeature) => {
     const regionName = regionMap[parseInt(stateFeature.properties.regiao_id)];
     const stateName = stateFeature.properties.name;
+    const stateSigla = stateFeature.properties.sigla;
 
     // Passa os dados
-    onRegionChange?.({ regiao: regionName, estado: stateName });
+    onRegionChange?.({ regiao: regionName, estado: stateName , uf: stateSigla});
 
     // Reseta seleção e ativa zoom pro Brasil
     setSelectedRegion(null);

--- a/src/components/Maps/MultiBrazilMap.jsx
+++ b/src/components/Maps/MultiBrazilMap.jsx
@@ -1,0 +1,161 @@
+import { MapContainer, GeoJSON, useMap } from "react-leaflet";
+import "leaflet/dist/leaflet.css";
+import statesData from "../../assets/geojson/brazil-states.json";
+import { useState, useEffect } from "react";
+import L from "leaflet";
+import "./../../App.css";
+
+const regionMap = {
+  1: "Norte",
+  2: "Nordeste",
+  3: "Sudeste",
+  4: "Sul",
+  5: "Centro-Oeste",
+};
+
+export const regionColors = {
+  Norte: "#14A538",
+  Nordeste: "#EB641C",
+  "Centro-Oeste": "#F79F44",
+  Sudeste: "#028391",
+  Sul: "#731CA5",
+};
+
+// Componente que ajusta o zoom automaticamente
+const FitBounds = ({ features }) => {
+  const map = useMap();
+
+  useEffect(() => {
+    if (features?.length) {
+      const geoJsonLayer = L.geoJSON(features);
+      map.fitBounds(geoJsonLayer.getBounds(), {
+        padding: [20, 20],
+      });
+    }
+  }, [features, map]);
+
+  return null;
+};
+
+const BrazilMap = ({ onRegionChange }) => {
+  const [regions, setRegions] = useState({});
+  const [selectedRegion, setSelectedRegion] = useState(null);
+  const [zoomToBrazil, setZoomToBrazil] = useState(false);
+
+  useEffect(() => {
+    const grouped = {};
+    statesData.features.forEach((feature) => {
+      const regiaoId = parseInt(feature.properties.regiao_id);
+      const regiaoNome = regionMap[regiaoId];
+      if (!grouped[regiaoNome]) grouped[regiaoNome] = [];
+      grouped[regiaoNome].push(feature);
+    });
+    setRegions(grouped);
+  }, []);
+
+  const getSelectedRegionFeatures = () => {
+    return selectedRegion ? regions[selectedRegion] : statesData.features;
+  };
+
+  const handleRegionClick = (regionName) => {
+    setSelectedRegion(regionName);
+    setZoomToBrazil(false);
+    onRegionChange?.({ regiao: regionName, estado: null });
+  };
+
+  const handleStateClick = (stateFeature) => {
+    const regionName = regionMap[parseInt(stateFeature.properties.regiao_id)];
+    const stateName = stateFeature.properties.name;
+
+    // Passa os dados
+    onRegionChange?.({ regiao: regionName, estado: stateName });
+
+    // Reseta seleção e ativa zoom pro Brasil
+    setSelectedRegion(null);
+    setZoomToBrazil(true);
+  };
+
+  const renderGeoJSON = () => {
+    // Se nenhuma região selecionada → mostra o Brasil
+    if (!selectedRegion) {
+      return Object.entries(regions).map(([regionName, features], index) => (
+        <GeoJSON
+          key={index}
+          data={{ type: "FeatureCollection", features }}
+          style={{
+            color: regionColors[regionName],
+            weight: 1,
+            fillColor: regionColors[regionName],
+            fillOpacity: 1,
+            cursor: "pointer",
+          }}
+          eventHandlers={{
+            click: (e) => {
+              e.originalEvent.stopPropagation();
+              handleRegionClick(regionName);
+            },
+          }}
+          onEachFeature={(feature, layer) => {
+            layer.bindPopup(regionName);
+          }}
+        />
+      ));
+    }
+
+    // Se uma região estiver selecionada → mostra só os estados dela
+    return (
+      <GeoJSON
+        key={`region-${selectedRegion}`}
+        data={{
+          type: "FeatureCollection",
+          features: regions[selectedRegion],
+        }}
+        style={{
+          color: "var(--white-500)",
+          weight: 2,
+          fillColor: regionColors[selectedRegion],
+          fillOpacity: 1,
+          cursor: "pointer",
+        }}
+        onEachFeature={(feature, layer) => {
+          const stateName = feature.properties.name;
+          layer.on({
+            click: () => handleStateClick(feature),
+          });
+          layer.bindPopup(stateName);
+        }}
+      />
+    );
+  };
+
+  const currentFeatures = zoomToBrazil
+    ? statesData.features // força zoom no Brasil todo
+    : getSelectedRegionFeatures(); // região ou tudo
+
+  return (
+    <div className="brazil-map-container">
+      <MapContainer
+        center={[-14.235, -51.9253]}
+        zoomSnap={0.1}
+        zoom={6}
+        style={{
+          height: "40em",
+          width: "100%",
+          borderRadius: "12px",
+        }}
+        dragging={false}
+        scrollWheelZoom={false}
+        doubleClickZoom={false}
+        touchZoom={false}
+        boxZoom={false}
+        keyboard={false}
+        zoomControl={false}
+      >
+        {renderGeoJSON()}
+        <FitBounds features={currentFeatures} />
+      </MapContainer>
+    </div>
+  );
+};
+
+export default BrazilMap;

--- a/src/pages/comparisonStats/ComparisonStats.jsx
+++ b/src/pages/comparisonStats/ComparisonStats.jsx
@@ -16,6 +16,22 @@ import Dropdown from '../../components/Dropdown/Dropdown'
 import { faCircleInfo } from "@fortawesome/free-solid-svg-icons"
 
 const ComparisonStats = () => {
+
+    const [region, setRegion] = useState('');
+    const [state, setState] = useState('');
+
+    // Opções de descrição para o mapa do Brasil
+    const getDescriptionText = () => {
+        if (state) { //Selecionou um estado
+        return "Para desfazer a seleção de estado atual, clique no mapa abaixo.";
+        } else if (region) { //Selecionou uma região
+        return "Escolha um dos estados para analisar seus dados.";
+        } else { //Não selecionou nada
+        return "Para selecionar um estado, escolha uma das regiões do mapa abaixo.";
+        }
+    };
+
+
     // TESTE ATUALIZAÇÃO DO ESTADO YEAR
     const dadosTeste = {
       exportacao: [
@@ -141,7 +157,6 @@ const ComparisonStats = () => {
         },
       ]
     };
-
     
     // Variáveis para os inputs
     const [product , setProduct] = useState('')
@@ -250,7 +265,18 @@ const ComparisonStats = () => {
 
             <section id={styles.primaryInfos}>
                 <div className={styles.navMap}>
-                    <BrazilMap/>
+                    
+                    {/* Legenda do mapa do brasil */}
+                    <p className={styles.mapDescription}>{getDescriptionText()}</p>
+
+                    {/* Região/Estado selecionado */}
+                    {state ? (
+                    <h2 className={styles.mapCurrentState}>{state}</h2>
+                    ) : region ? (
+                    <h2 className={styles.mapCurrentState}>Região {region}</h2>
+                    ) : null}
+
+                    <BrazilMap onRegionChange={({ regiao, estado }) => { setRegion(regiao ?? undefined); setState(estado ?? undefined);}} />
                 </div>
 
                 <section className={`${styles.infoGridVertical} infoGridVertical`}>

--- a/src/pages/comparisonStats/ComparisonStats.jsx
+++ b/src/pages/comparisonStats/ComparisonStats.jsx
@@ -50,14 +50,16 @@ const ComparisonStats = () => {
 
     console.log(statesList)
     
-    // Opções de descrição para o mapa do Brasil
+    // Opções de descrição para o mapa do Brasil (para comparação)
     const getDescriptionText = () => {
-        if (state) { //Selecionou um estado
-        return "Para desfazer a seleção de estado atual, clique no mapa abaixo.";
+        if (statesList.length >= 2) { //Selecionou dois estados
+            return "Para desfazer a seleção de um dos estados, clique em seu nome abaixo.";
+        } else if (statesList.length >= 1) { //Selecionou um estado
+            return "Para selecionar o segundo estado, escolha mais uma das regiões do mapa.";
         } else if (region) { //Selecionou uma região
-        return "Escolha um dos estados para analisar seus dados.";
+            return "Escolha um dos estados dessa região para analisar seus dados.";
         } else { //Não selecionou nada
-        return "Para selecionar um estado, escolha uma das regiões do mapa abaixo.";
+            return "Para começar a comparação entre estados, escolha uma das regiões do mapa abaixo."
         }
     };
 

--- a/src/pages/comparisonStats/ComparisonStats.jsx
+++ b/src/pages/comparisonStats/ComparisonStats.jsx
@@ -21,6 +21,7 @@ const ComparisonStats = () => {
 
     const [region, setRegion] = useState('');
     const [state, setState] = useState('');
+    const [uf , setUf] = useState('');
     const [statesList , setStatesList] = useState([]);
     
     // Mudando a lista de estados quando um estado novo for selecionado
@@ -30,13 +31,18 @@ const ComparisonStats = () => {
                 return
             }
             setStatesList(previewList => {
-                const updatedList = [...previewList] //Cópia de segurança do conteúdo da lista anterior
+                const currentList = [...previewList] //Cópia de segurança do conteúdo da lista anterior
                 // Caso a lista já tenha 2 elementos, remove o último
-                if(updatedList.length >= 2){
-                    updatedList.pop()
+                if(currentList.length >= 2){
+                    currentList.pop()
                 }
                 // Adiciona o novo estado selecionado no BrazilMap
-                return [...updatedList , state]
+                let newStateObject = {
+                    estado: state,
+                    uf: uf,
+                }
+
+                return [...currentList , newStateObject]
             })
         }
     }, [state])
@@ -307,9 +313,9 @@ const ComparisonStats = () => {
                             <p className={styles.statesList}>
                                 [
                                 {statesList[0] && <>   
-                                    <span onClick={() => {removeStateByIndex(0)}} style={{color:'var(--base-green)'}}> <FontAwesomeIcon icon={faX} className={styles.icon}/> {statesList[0]} </span> </> }
+                                    <span onClick={() => {removeStateByIndex(0)}} style={{color:'var(--base-green)'}}> <FontAwesomeIcon icon={faX} className={styles.icon}/> {statesList[0].estado} </span> </> }
                                 {statesList[1] && <> | 
-                                    <span onClick={() => {removeStateByIndex(1)}} style={{color:'var(--base-teal)'}}> <FontAwesomeIcon icon={faX} className={styles.icon}/> {statesList[1]} </span> </>}
+                                    <span onClick={() => {removeStateByIndex(1)}} style={{color:'var(--base-teal)'}}> <FontAwesomeIcon icon={faX} className={styles.icon}/> {statesList[1].estado} </span> </>}
                                 ]
                             </p>
                         }
@@ -320,9 +326,10 @@ const ComparisonStats = () => {
                         <h2 className={styles.mapCurrentState}>Região {region}</h2>
                     )}
 
-                    <MultiBrazilMap onRegionChange={({ regiao, estado }) => { 
+                    <MultiBrazilMap onRegionChange={({ regiao, estado , uf}) => { 
                         setRegion(regiao || '');
                         setState(estado || '');
+                        setUf(uf || '');
                     }} />
                 </div>
 

--- a/src/pages/comparisonStats/ComparisonStats.jsx
+++ b/src/pages/comparisonStats/ComparisonStats.jsx
@@ -14,6 +14,8 @@ import IconTitle from '../../components/IconTitle/IconTitle'
 import Dropdown from '../../components/Dropdown/Dropdown'
 
 import { faCircleInfo } from "@fortawesome/free-solid-svg-icons"
+import { faX } from "@fortawesome/free-solid-svg-icons"
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 const ComparisonStats = () => {
 
@@ -38,6 +40,13 @@ const ComparisonStats = () => {
             })
         }
     }, [state])
+
+    const removeStateByIndex = (index) => {
+        setStatesList( previewList => [
+            ...previewList.slice(0 , index),
+            ...previewList.slice(index + 1)
+        ])
+    }
 
     console.log(statesList)
     
@@ -290,19 +299,24 @@ const ComparisonStats = () => {
                     {/* Legenda do mapa do brasil */}
                     <p className={styles.mapDescription}>{getDescriptionText()}</p>
                     
-                    {statesList[1] ?
-                        <p className={styles.mapDescription}>[ {statesList[0]} | {statesList[1]} ]</p> :
-                    statesList[0] ?
-                        <p className={styles.mapDescription}>[ {statesList[0]} ]</p> : 
-                        null
-                    }
+                    {/* Nomes dos estados */}
+                    <div id={styles.statesListContainer}>
+                        {statesList.length >= 1 &&
+                            <p className={styles.statesList}>
+                                [
+                                {statesList[0] && <>   
+                                    <span onClick={() => {removeStateByIndex(0)}} style={{color:'var(--base-green)'}}> <FontAwesomeIcon icon={faX} className={styles.icon}/> {statesList[0]} </span> </> }
+                                {statesList[1] && <> | 
+                                    <span onClick={() => {removeStateByIndex(1)}} style={{color:'var(--base-teal)'}}> <FontAwesomeIcon icon={faX} className={styles.icon}/> {statesList[1]} </span> </>}
+                                ]
+                            </p>
+                        }
+                    </div>
 
-                    {/* Região/Estado selecionado */}
-                    {state ? 
-                        null : 
-                    region ? (
+                    {/* Exibir região selecionada */}
+                    {(region && !state) && (
                         <h2 className={styles.mapCurrentState}>Região {region}</h2>
-                    ) : null}
+                    )}
 
                     <MultiBrazilMap onRegionChange={({ regiao, estado }) => { 
                         setRegion(regiao || '');

--- a/src/pages/comparisonStats/ComparisonStats.jsx
+++ b/src/pages/comparisonStats/ComparisonStats.jsx
@@ -21,57 +21,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 const ComparisonStats = () => {
 
-    const [region, setRegion] = useState('');
-    const [state, setState] = useState('');
-    const [uf , setUf] = useState('');
-    const [statesList , setStatesList] = useState([]);
-    
-    // Mudando a lista de estados quando um estado novo for selecionado
-    useEffect(() => {
-        if (state) {
-            if(statesList[0] == state){
-                return
-            }
-            setStatesList(previewList => {
-                const currentList = [...previewList] //Cópia de segurança do conteúdo da lista anterior
-                // Caso a lista já tenha 2 elementos, remove o último
-                if(currentList.length >= 2){
-                    currentList.pop()
-                }
-                // Adiciona o novo estado selecionado no BrazilMap
-                let newStateObject = {
-                    estado: state,
-                    uf: uf,
-                }
-
-                return [...currentList , newStateObject]
-            })
-        }
-    }, [state])
-
-    const removeStateByIndex = (index) => {
-        setStatesList( previewList => [
-            ...previewList.slice(0 , index),
-            ...previewList.slice(index + 1)
-        ])
-    }
-
-    console.log(statesList)
-    
-    // Opções de descrição para o mapa do Brasil (para comparação)
-    const getDescriptionText = () => {
-        if (statesList.length >= 2) { //Selecionou dois estados
-            return "Para desfazer a seleção de um dos estados, clique em seu nome abaixo.";
-        } else if (statesList.length >= 1) { //Selecionou um estado
-            return "Para selecionar o segundo estado, escolha mais uma das regiões do mapa.";
-        } else if (region) { //Selecionou uma região
-            return "Escolha um dos estados dessa região para analisar seus dados.";
-        } else { //Não selecionou nada
-            return "Para começar a comparação entre estados, escolha uma das regiões do mapa abaixo."
-        }
-    };
-
-
     // TESTE ATUALIZAÇÃO DO ESTADO YEAR
     const dadosTeste = {
       exportacao: [
@@ -198,13 +147,65 @@ const ComparisonStats = () => {
       ]
     };
 
-    // Variáveis para os inputs
+    // STATES DOS FILTROS
+    // Produto
     const [product , setProduct] = useState('')
     const [sh, setSh] = useState('sh4');
 
+    // Período
     const [periodoUnico, setPeriodoUnico] = useState(true);
     const [initYear , setInitYear] = useState(2014)
     const [finalYear , setFinalYear] = useState(2024)
+
+    // Estado
+    const [region, setRegion] = useState('');
+    const [state, setState] = useState('');
+    const [uf , setUf] = useState('');
+    const [statesList , setStatesList] = useState([]);
+
+    // Mudando a lista de estados quando um estado novo for selecionado
+    useEffect(() => {
+        if (state) {
+            if(statesList[0] == state){
+                return
+            }
+            setStatesList(previewList => {
+                const currentList = [...previewList] //Cópia de segurança do conteúdo da lista anterior
+                // Caso a lista já tenha 2 elementos, remove o último
+                if(currentList.length >= 2){
+                    currentList.pop()
+                }
+                // Adiciona o novo estado selecionado no BrazilMap
+                let newStateObject = {
+                    state: state,
+                    uf: uf,
+                }
+
+                return [...currentList , newStateObject]
+            })
+        }
+    }, [state])
+
+    const removeStateByIndex = (index) => {
+        setStatesList( previewList => [
+            ...previewList.slice(0 , index),
+            ...previewList.slice(index + 1)
+        ])
+    }
+    
+    // Opções de descrição para o mapa do Brasil (para comparação)
+    const getDescriptionText = () => {
+        if (statesList.length >= 2) { //Selecionou dois estados
+            return "Para desfazer a seleção de um dos estados, clique em seu nome abaixo.";
+        } else if (statesList.length >= 1) { //Selecionou um estado
+            return "Para selecionar o segundo estado, escolha mais uma das regiões do mapa.";
+        } else if (region) { //Selecionou uma região
+            return "Escolha um dos estados dessa região para analisar seus dados.";
+        } else { //Não selecionou nada
+            return "Para começar a comparação entre estados, escolha uma das regiões do mapa abaixo."
+        }
+    };
+
 
     const opcoesDeProduto = ["Abacaxi" , "Cenoura"];
     const years = [2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024];
@@ -292,9 +293,9 @@ const ComparisonStats = () => {
                             <p className={styles.statesList}>
                                 [
                                 {statesList[0] && <>   
-                                    <span onClick={() => {removeStateByIndex(0)}} style={{color:'var(--base-green)'}}> <FontAwesomeIcon icon={faX} className={styles.icon}/> {statesList[0].estado} </span> </> }
+                                    <span onClick={() => {removeStateByIndex(0)}} style={{color:'var(--base-green)'}}> <FontAwesomeIcon icon={faX} className={styles.icon}/> {statesList[0].state} </span> </> }
                                 {statesList[1] && <> | 
-                                    <span onClick={() => {removeStateByIndex(1)}} style={{color:'var(--base-teal)'}}> <FontAwesomeIcon icon={faX} className={styles.icon}/> {statesList[1].estado} </span> </>}
+                                    <span onClick={() => {removeStateByIndex(1)}} style={{color:'var(--base-teal)'}}> <FontAwesomeIcon icon={faX} className={styles.icon}/> {statesList[1].state} </span> </>}
                                 ]
                             </p>
                         }

--- a/src/pages/comparisonStats/ComparisonStats.jsx
+++ b/src/pages/comparisonStats/ComparisonStats.jsx
@@ -7,7 +7,7 @@ import DoubleLineChart from '../../components/Charts/DoubleLineChart'
 import ColorCard from '../../components/Cards/ColorCard/ColorCard'
 import BarChart from '../../components/Charts/BarChart'
 import AlertCard from '../../components/Cards/AlertCard/AlertCard'
-import BrazilMap from '../../components/Maps/BrazilMap'
+import MultiBrazilMap from '../../components/Maps/MultiBrazilMap'
 import WorldMap from '../../components/Maps/WorldMap'
 import Checkbox from '../../components/Buttons/Checkbox/Checkbox'
 import IconTitle from '../../components/IconTitle/IconTitle'
@@ -19,7 +19,28 @@ const ComparisonStats = () => {
 
     const [region, setRegion] = useState('');
     const [state, setState] = useState('');
+    const [statesList , setStatesList] = useState([]);
+    
+    // Mudando a lista de estados quando um estado novo for selecionado
+    useEffect(() => {
+        if (state) {
+            if(statesList[0] == state){
+                return
+            }
+            setStatesList(previewList => {
+                const updatedList = [...previewList] //Cópia de segurança do conteúdo da lista anterior
+                // Caso a lista já tenha 2 elementos, remove o último
+                if(updatedList.length >= 2){
+                    updatedList.pop()
+                }
+                // Adiciona o novo estado selecionado no BrazilMap
+                return [...updatedList , state]
+            })
+        }
+    }, [state])
 
+    console.log(statesList)
+    
     // Opções de descrição para o mapa do Brasil
     const getDescriptionText = () => {
         if (state) { //Selecionou um estado
@@ -157,7 +178,7 @@ const ComparisonStats = () => {
         },
       ]
     };
-    
+
     // Variáveis para os inputs
     const [product , setProduct] = useState('')
     const [sh, setSh] = useState('sh4');
@@ -268,15 +289,25 @@ const ComparisonStats = () => {
                     
                     {/* Legenda do mapa do brasil */}
                     <p className={styles.mapDescription}>{getDescriptionText()}</p>
+                    
+                    {statesList[1] ?
+                        <p className={styles.mapDescription}>[ {statesList[0]} | {statesList[1]} ]</p> :
+                    statesList[0] ?
+                        <p className={styles.mapDescription}>[ {statesList[0]} ]</p> : 
+                        null
+                    }
 
                     {/* Região/Estado selecionado */}
-                    {state ? (
-                    <h2 className={styles.mapCurrentState}>{state}</h2>
-                    ) : region ? (
-                    <h2 className={styles.mapCurrentState}>Região {region}</h2>
+                    {state ? 
+                        null : 
+                    region ? (
+                        <h2 className={styles.mapCurrentState}>Região {region}</h2>
                     ) : null}
 
-                    <BrazilMap onRegionChange={({ regiao, estado }) => { setRegion(regiao ?? undefined); setState(estado ?? undefined);}} />
+                    <MultiBrazilMap onRegionChange={({ regiao, estado }) => { 
+                        setRegion(regiao || '');
+                        setState(estado || '');
+                    }} />
                 </div>
 
                 <section className={`${styles.infoGridVertical} infoGridVertical`}>

--- a/src/pages/comparisonStats/ComparisonStats.module.css
+++ b/src/pages/comparisonStats/ComparisonStats.module.css
@@ -137,7 +137,6 @@ section#primaryInfos .navMap {
     .navMap .mapDescription {
         color: var(--black-500);
         font: var(--text-medium);
-        text-align: center;
     }
 
 /* Dados de Exportação / Importação */

--- a/src/pages/comparisonStats/ComparisonStats.module.css
+++ b/src/pages/comparisonStats/ComparisonStats.module.css
@@ -129,7 +129,6 @@ section#primaryInfos .navMap {
     .navMap .mapDescription {
         color: var(--black-500);
         font: var(--text-medium);
-        text-align: center;
     }
 
     div#statesListContainer{
@@ -137,7 +136,6 @@ section#primaryInfos .navMap {
 
         div#statesListContainer p.statesList{
             display: flex;
-            justify-content: center;
             align-items: center;
             gap: 20px;
 
@@ -153,7 +151,6 @@ section#primaryInfos .navMap {
                 align-items: center;
                 gap: 10px;
                 font-weight: 600;
-                text-align: center;
 
                 transition: all 150ms ease-out;
             }

--- a/src/pages/comparisonStats/ComparisonStats.module.css
+++ b/src/pages/comparisonStats/ComparisonStats.module.css
@@ -126,6 +126,19 @@ section#primaryInfos .navMap {
     height: 100%;
 }
 
+    /* Legenda do mapa do brasil */
+    .navMap .mapCurrentState{
+        margin-top: 0.875rem;
+        color: var(--black-500);
+        font: var(--title-regular);
+        text-align: center;
+    }
+
+    .navMap .mapDescription {
+        color: var(--black-500);
+        font: var(--text-medium);
+        text-align: center;
+    }
 
 /* Dados de Exportação / Importação */
 section#ExpImpInfos {

--- a/src/pages/comparisonStats/ComparisonStats.module.css
+++ b/src/pages/comparisonStats/ComparisonStats.module.css
@@ -126,17 +126,53 @@ section#primaryInfos .navMap {
     height: 100%;
 }
 
+    .navMap .mapDescription {
+        color: var(--black-500);
+        font: var(--text-medium);
+        text-align: center;
+    }
+
+    div#statesListContainer{
+    }
+
+        div#statesListContainer p.statesList{
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            gap: 20px;
+
+            color: var(--black-500);
+            font: var(--text-medium);
+            text-align: center;
+        }
+
+            div#statesListContainer p.statesList span{
+                cursor: pointer;
+
+                display: flex;
+                align-items: center;
+                gap: 10px;
+                font-weight: 600;
+                text-align: center;
+
+                transition: all 150ms ease-out;
+            }
+
+                div#statesListContainer p.statesList span:hover{
+                    transform: scale(1.03);
+                }
+
+                div#statesListContainer p.statesList span .icon{
+                    color: var(--black-500);
+                    font: var(--label-medium);
+                }
+
     /* Legenda do mapa do brasil */
     .navMap .mapCurrentState{
         margin-top: 0.875rem;
         color: var(--black-500);
         font: var(--title-regular);
         text-align: center;
-    }
-
-    .navMap .mapDescription {
-        color: var(--black-500);
-        font: var(--text-medium);
     }
 
 /* Dados de Exportação / Importação */

--- a/src/pages/statistics/Statistics.jsx
+++ b/src/pages/statistics/Statistics.jsx
@@ -42,6 +42,17 @@ const Statistics = () => {
     const [vlFob, setVlFob] = useState([])
     const [countries, setCountries] = useState([])
 
+    // Opções de descrição para o mapa do Brasil
+    const getDescriptionText = () => {
+        if (state) { //Selecionou um estado
+        return "Para desfazer a seleção de estado atual, clique no mapa abaixo.";
+        } else if (region) { //Selecionou uma região
+        return "Escolha um dos estados para analisar seus dados.";
+        } else { //Não selecionou nada
+        return "Para selecionar um estado, escolha uma das regiões do mapa abaixo.";
+        }
+    };
+
     const getProductByLetter = async () => {
         if (product.length > 0) {
             try {
@@ -540,6 +551,16 @@ const Statistics = () => {
             <section id={styles.primaryInfos}>
                 {/* Mapa do Brasil */}
                 <div className={styles.navMap}>
+
+                    {/* Legenda do mapa do brasil */}
+                    <p className={styles.mapDescription}>{getDescriptionText()}</p>
+
+                    {/* Região/Estado selecionado */}
+                    {state ? (
+                    <h2 className={styles.mapCurrentState}>{state}</h2>
+                    ) : region ? (
+                    <h2 className={styles.mapCurrentState}>Região {region}</h2>
+                    ) : null}
                     <BrazilMap onRegionChange={({ regiao, estado }) => { setRegion(regiao ?? undefined); setState(estado ?? undefined);}} />
                 </div>
 

--- a/src/pages/statistics/Statistics.jsx
+++ b/src/pages/statistics/Statistics.jsx
@@ -42,14 +42,14 @@ const Statistics = () => {
     const [vlFob, setVlFob] = useState([])
     const [countries, setCountries] = useState([])
 
-    // Opções de descrição para o mapa do Brasil
+    // Opções de descrição para o mapa do Brasil (para estatísticas)
     const getDescriptionText = () => {
         if (state) { //Selecionou um estado
-        return "Para desfazer a seleção de estado atual, clique no mapa abaixo.";
+            return "Para desfazer a seleção de estado atual, clique no mapa abaixo.";
         } else if (region) { //Selecionou uma região
-        return "Escolha um dos estados para analisar seus dados.";
+            return "Escolha um dos estados para analisar seus dados.";
         } else { //Não selecionou nada
-        return "Para selecionar um estado, escolha uma das regiões do mapa abaixo.";
+            return "Para ver estatísticas de um estado, escolha uma das regiões do mapa abaixo.";
         }
     };
 

--- a/src/pages/statistics/Statistics.jsx
+++ b/src/pages/statistics/Statistics.jsx
@@ -17,17 +17,24 @@ import IconTitle from '../../components/IconTitle/IconTitle'
 import styles from './Statistics.module.css'
 
 const Statistics = () => {
-    // states dos filtros
+    // STATES DOS FILTROS
+    // Produto
     const [sh, setSh] = useState('sh4');
     const [product, setProduct] = useState('');
-    const [state, setState] = useState('');
-    const [tradeType, setTradeType] = useState('exportacao');
-    const [region, setRegion] = useState('');
+
+    // Período
     const [initYear, setInitYear] = useState(2014);
     const [finalYear, setFinalYear] = useState(2024);
     const [periodoUnico, setPeriodoUnico] = useState(true);
     const [period, setPeriod] = useState([initYear, finalYear]);
 
+    // Estado
+    const [region, setRegion] = useState('');
+    const [state, setState] = useState('');
+    const [uf , setUf] = useState('');
+
+    const [tradeType, setTradeType] = useState('exportacao');
+    
     // state de opções dos inputs
     const [opcoesDeProduto, setOpcoesDeProduto] = useState([]);
     const years = [2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024];
@@ -561,7 +568,11 @@ const Statistics = () => {
                     ) : region ? (
                     <h2 className={styles.mapCurrentState}>Região {region}</h2>
                     ) : null}
-                    <BrazilMap onRegionChange={({ regiao, estado }) => { setRegion(regiao ?? undefined); setState(estado ?? undefined);}} />
+                    <BrazilMap onRegionChange={ ({ regiao, estado , uf }) => {
+                        setRegion(regiao || ''); 
+                        setState(estado || ''); 
+                        setUf(uf || '');
+                    }} />
                 </div>
 
                 {/* Molde de Grid Vertical Reutilizável */}

--- a/src/pages/statistics/Statistics.module.css
+++ b/src/pages/statistics/Statistics.module.css
@@ -100,6 +100,19 @@ section#primaryInfos .navMap {
     height: 100%;
 }
 
+    /* Legenda do mapa do brasil */
+    .navMap .mapCurrentState{
+        margin-top: 0.875rem;
+        color: var(--black-500);
+        font: var(--title-regular);
+        text-align: center;
+    }
+
+    .navMap .mapDescription {
+        color: var(--black-500);
+        font: var(--text-medium);
+        text-align: center;
+    }
 
 /* Dados de Exportação / Importação */
 section#ExpImpInfos {


### PR DESCRIPTION
## [[FE-PCOMP-1] Criar layout da página de comparação ](https://trello.com/c/FfKGqK3x)## 

**Branch**

- feature/region-filter-comparison-layout
---
**O que foi implementado ou alterado?**

- Componente MultiBrazilMap, variação do BrazilMap, porém com comportamento próprio para o filtro de estado na página de comparação.
- As Iegendas dos mapas do brasiI foram coIocados fora do componente e diretamente dentro da página.
- Mapas do BrasiI retornam a UF do estado seIecionado para fazer chamadas nas rotas (Retornam de formas diferentes em cada página: Na página de estatísticas, muda o estado da variáveI "uf". Na página de comparação, retorna como o índice de um objeto alocado no array statesList)
---
**Passos para testar**

1. Verificar o retorno do estado e da UF na página de estatísticas: 
console.log(state); console.log(uf)
2. Verificar o retorno do estado e da UF na página de comparação:
console.log(statesList[0].state); console.log(statesList[0].uf)
---
**Reviewers**
- @YgorPereira 
